### PR TITLE
MacOS Fix

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,4 @@
-import { dirname } from 'node:path';
+import { dirname } from 'path';
 import { fileURLToPath } from 'node:url';
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';

--- a/packages/adblocker-electron/src/preload_path-cjs.cts
+++ b/packages/adblocker-electron/src/preload_path-cjs.cts
@@ -1,3 +1,3 @@
-import { resolve } from 'node:path';
+import { resolve } from 'path';
 
 export const PRELOAD_PATH = resolve(require.resolve('@ghostery/adblocker-electron-preload'));

--- a/packages/adblocker/assets/update.js
+++ b/packages/adblocker/assets/update.js
@@ -1,7 +1,7 @@
 /* global fetch */
 
 import { writeFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname } from 'path';
 import { fileURLToPath } from 'node:url';
 import { log } from 'node:console';
 import { NetworkFilter, parseFilter } from '@ghostery/adblocker';

--- a/packages/adblocker/tools/auto-bump-engine-version.ts
+++ b/packages/adblocker/tools/auto-bump-engine-version.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync } from 'node:fs';
-import { resolve, join, dirname } from 'node:path';
+import { resolve, join, dirname } from 'path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/packages/adblocker/tools/engine-size.ts
+++ b/packages/adblocker/tools/engine-size.ts
@@ -7,7 +7,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname } from 'path';
 import { fileURLToPath } from 'node:url';
 import { gzipSync, brotliCompressSync } from 'node:zlib';
 

--- a/packages/adblocker/tools/generate_compression_codebooks.ts
+++ b/packages/adblocker/tools/generate_compression_codebooks.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'node:fs';
-import { resolve, join, dirname } from 'node:path';
+import { resolve, join, dirname } from 'path';
 import { fileURLToPath } from 'node:url';
 import { generate } from '@remusao/smaz-generate';
 import { Smaz } from '@remusao/smaz';

--- a/packages/adblocker/tools/priorities.ts
+++ b/packages/adblocker/tools/priorities.ts
@@ -7,7 +7,7 @@
  */
 
 import { promises as fs } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname } from 'path';
 import { fileURLToPath } from 'node:url';
 
 import {


### PR DESCRIPTION
This pull request addresses a bug encountered on MacOS where using the node:path module results in execution errors. On MacOS, the node:path import is not properly recognized, leading to failures during execution.

**Changes Made:**
Replaced Import Statements:
All occurrences of node:path have been updated to node throughout the codebase. This change ensures that the correct module is imported and that the feature works seamlessly across all platforms, including MacOS.

This fixes the compatibility issue without affecting functionality on other operating systems.